### PR TITLE
Topic/issue 7 hint error

### DIFF
--- a/.github/workflows/nuget.yml
+++ b/.github/workflows/nuget.yml
@@ -16,7 +16,7 @@ jobs:
       - name: Setup .NET
         uses: actions/setup-dotnet@v1
         with:
-          dotnet-version: 5.0.x
+          dotnet-version: 6.0.x
           
       - name: Restore dependencies
         run: dotnet restore

--- a/InterfaceGenerator/AutoInterfaceGenerator.cs
+++ b/InterfaceGenerator/AutoInterfaceGenerator.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.CodeDom.Compiler;
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.Globalization;
 using System.IO;
 using System.Linq;
@@ -21,6 +22,13 @@ namespace InterfaceGenerator
         public void Initialize(GeneratorInitializationContext context)
         {
             context.RegisterForSyntaxNotifications(() => new SyntaxReceiver());
+
+#if DEBUG
+            if (!Debugger.IsAttached)
+            {
+                Debugger.Launch();
+            }
+#endif
         }
 
         public void Execute(GeneratorExecutionContext context)
@@ -83,6 +91,8 @@ namespace InterfaceGenerator
 
             var classSymbols = GetImplTypeSymbols(compilation, receiver);
 
+            List<string> classSymbolNames = new List<string>();
+
             foreach (var implTypeSymbol in classSymbols)
             {
                 if (!implTypeSymbol.TryGetAttribute(_generateAutoInterfaceAttribute, out var attributes))
@@ -90,9 +100,17 @@ namespace InterfaceGenerator
                     continue;
                 }
 
+                if(classSymbolNames.Contains(implTypeSymbol.GetFullMetadataName(useNameWhenNotFound: true)))
+                {
+                    continue; // partial class, already added
+                }
+
+                classSymbolNames.Add(implTypeSymbol.GetFullMetadataName(useNameWhenNotFound: true));
+
                 var attribute = attributes.Single(); 
                 var source = SourceText.From(GenerateInterfaceCode(implTypeSymbol, attribute), Encoding.UTF8);
-                context.AddSource($"{implTypeSymbol.Name}_AutoInterface.cs", source);
+
+                context.AddSource($"{implTypeSymbol.GetFullMetadataName(useNameWhenNotFound: true)}_AutoInterface.cs", source);
             }
         }
 

--- a/InterfaceGenerator/InterfaceGenerator.csproj
+++ b/InterfaceGenerator/InterfaceGenerator.csproj
@@ -3,7 +3,7 @@
         <TargetFramework>netstandard2</TargetFramework>
         <LangVersion>9.0</LangVersion>
         <Nullable>enable</Nullable>
-        <PackageVersion>1.0.9</PackageVersion>
+        <PackageVersion>1.0.10</PackageVersion>
 
 		<developmentDependency>true</developmentDependency>
 		<GeneratePackageOnBuild>false</GeneratePackageOnBuild>

--- a/InterfaceGenerator/SymbolExtensions.cs
+++ b/InterfaceGenerator/SymbolExtensions.cs
@@ -1,5 +1,6 @@
 ﻿using System.Collections.Generic;
 using System.Linq;
+using System.Text;
 using Microsoft.CodeAnalysis;
 
 namespace InterfaceGenerator
@@ -20,6 +21,49 @@ namespace InterfaceGenerator
         {
             return symbol.GetAttributes()
                          .Any(a => SymbolEqualityComparer.Default.Equals(a.AttributeClass, attributeType));
+        }
+
+        //Ref: https://stackoverflow.com/questions/27105909/get-fully-qualified-metadata-name-in-roslyn
+        public static string GetFullMetadataName(this ISymbol s, bool useNameWhenNotFound = false)
+        {
+            if (s == null || IsRootNamespace(s))
+            {
+                if (useNameWhenNotFound)
+                {
+                    return s.Name;
+                }
+                return string.Empty;
+            }
+
+            var sb = new StringBuilder(s.MetadataName);
+            var last = s;
+
+            s = s.ContainingSymbol;
+
+            while (!IsRootNamespace(s))
+            {
+                if (s is ITypeSymbol && last is ITypeSymbol)
+                {
+                    sb.Insert(0, '+');
+                }
+                else
+                {
+                    sb.Insert(0, '.');
+                }
+
+                sb.Insert(0, s.OriginalDefinition.ToDisplayString(SymbolDisplayFormat.MinimallyQualifiedFormat));
+                //sb.Insert(0, s.MetadataName);
+                s = s.ContainingSymbol;
+            }
+
+            var retval = sb.ToString();
+            return string.IsNullOrEmpty(retval) && useNameWhenNotFound ? s.Name : retval;
+        }
+
+        private static bool IsRootNamespace(ISymbol symbol)
+        {
+            INamespaceSymbol s = null;
+            return ((s = symbol as INamespaceSymbol) != null) && s.IsGlobalNamespace;
         }
     }
 }


### PR DESCRIPTION
Ref: issue #7 
(EDIT: sorry I thought is was issue 3 first, but it is actually issue 7... my mistake)

Hi
I am proposing a change to use the full metadata name of the class, instead of just the name. So if there are any duplicates (within namespaces) you will not get any errors. Also a check is added to see if the metadata name is not already been used (for partial classes?)

Within my own solution I am using partial classes (I am generating a rest client with Swashbuckle when the Web Api project is build and this file is copied to the "interface" project. Here I have added the extra partial classes for my clients, so dependency injection is easier and I am adding the AutoInterfaceGenerator attribute).

So I have these modifications within my own solution and it works like a charm :-)

Please let me know what you think of this.
Kr
Edward

PS. I also added a way to use the debugger (this enables debugging while unittesting)