### PR TITLE
Fix handling of unmanaged type parameter constraint

### DIFF
--- a/InterfaceGenerator.Tests/MethodGenerationTests.cs
+++ b/InterfaceGenerator.Tests/MethodGenerationTests.cs
@@ -203,6 +203,34 @@ public class MethodGenerationTests
     }
 
     [Fact]
+    public void GenericVoidMethodWithValueTypeConstraints_IsImplemented()
+    {
+        var method = typeof(IMethodsTestService)
+                     .GetMethods()
+                     .First(x => x.Name == nameof(MethodsTestService.GenericVoidMethodWithValueTypeConstraints));
+
+        method.Should().NotBeNull();
+        method.ReturnType.Should().Be(typeof(void));
+
+        var genericArgs = method.GetGenericArguments();
+        genericArgs.Should().HaveCount(2);
+
+        genericArgs[0].IsValueType.Should().BeTrue();
+        genericArgs[0]
+            .GenericParameterAttributes.Should()
+            .HaveFlag(GenericParameterAttributes.DefaultConstructorConstraint)
+            .And.HaveFlag(GenericParameterAttributes.NotNullableValueTypeConstraint);
+
+        genericArgs[1].IsValueType.Should().BeTrue();
+        genericArgs[1]
+            .GenericParameterAttributes.Should()
+            .HaveFlag(GenericParameterAttributes.DefaultConstructorConstraint)
+            .And.HaveFlag(GenericParameterAttributes.NotNullableValueTypeConstraint);
+
+        _sut.GenericVoidMethodWithValueTypeConstraints<ValueTuple<int>, long>();
+    }
+
+    [Fact]
     public void VoidMethodWithOptionalParams_IsImplemented()
     {
         var method = typeof(IMethodsTestService)
@@ -312,6 +340,12 @@ internal class MethodsTestService : IMethodsTestService
     public void GenericVoidMethodWithConstraints<TX, TY>()
         where TX : class
         where TY : class, TX, new()
+    {
+    }
+
+    public void GenericVoidMethodWithValueTypeConstraints<TX, TY>()
+        where TX : struct
+        where TY : unmanaged
     {
     }
 

--- a/InterfaceGenerator/TypeParameterSymbolExtensions.cs
+++ b/InterfaceGenerator/TypeParameterSymbolExtensions.cs
@@ -7,23 +7,21 @@ namespace InterfaceGenerator
     {
         public static IEnumerable<string> EnumGenericConstraints(this ITypeParameterSymbol symbol)
         {
-            // the class/struct/unmanaged/notnull constraint has to be the last
+            // the class/struct/unmanaged/notnull constraint has to be the first
+            // and cannot be combined with one another
             if (symbol.HasNotNullConstraint)
             {
                 yield return "notnull";
             }
-            
-            if (symbol.HasValueTypeConstraint)
-            {
-                yield return "struct";
-            }
-            
-            if (symbol.HasUnmanagedTypeConstraint)
+            else if (symbol.HasUnmanagedTypeConstraint)
             {
                 yield return "unmanaged";
             }
-            
-            if (symbol.HasReferenceTypeConstraint)
+            else if (symbol.HasValueTypeConstraint)
+            {
+                yield return "struct";
+            }
+            else if (symbol.HasReferenceTypeConstraint)
             {
                 yield return symbol.ReferenceTypeConstraintNullableAnnotation == NullableAnnotation.Annotated
                     ? "class?"


### PR DESCRIPTION
When a method had the 'unmanaged' constraint specified, then the interface generator would output both 'struct' and 'unmanaged' constraints. However, the C# specification explicitly forbids to combine these constraints.

The problem is that when the `HasUnmanagedTypeConstraint` property of `ITypeParameterSymbol` is true, then `HasValueTypeConstraint` is also true. To fix the issue the `class` / `struct` / `unmanaged` / `notnull` constraints need to be treated as mutually exclusive, and `unmanaged` needs to be checked before `struct`.