### PR TITLE
Add nullable context

### DIFF
--- a/InterfaceGenerator.Tests/GenericInterfaceTests.cs
+++ b/InterfaceGenerator.Tests/GenericInterfaceTests.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Linq;
 using System.Reflection;
 using FluentAssertions;
 using Xunit;
@@ -26,6 +27,16 @@ public class GenericInterfaceTests
         genericArgs[0].GetGenericParameterConstraints().Should().HaveCount(1).And.Contain(iEquatableOfTx);
 
         genericArgs[1].IsValueType.Should().BeTrue();
+    }
+
+    [Fact]
+    public void IsNullableEnabled()
+    {
+        typeof(IGenericInterfaceTestsService<,>).GetCustomAttributes()
+            .Select(ca => ca.TypeId)
+            .OfType<Type>()
+            .Should()
+            .ContainSingle(at => at.FullName == "System.Runtime.CompilerServices.NullableContextAttribute");
     }
 }
 

--- a/InterfaceGenerator/AutoInterfaceGenerator.cs
+++ b/InterfaceGenerator/AutoInterfaceGenerator.cs
@@ -145,6 +145,8 @@ namespace InterfaceGenerator
             var interfaceName = InferInterfaceName(implTypeSymbol, attributeData);
             var visibilityModifier = InferVisibilityModifier(implTypeSymbol, attributeData);
 
+            codeWriter.WriteLine("#nullable enable");
+            codeWriter.WriteLine();
             codeWriter.WriteLine("namespace {0}", namespaceName);
             codeWriter.WriteLine("{");
 


### PR DESCRIPTION
Add nullable context to generated interface to fix warning

```
The annotation for nullable reference types should only be used in code within a '#nullable' annotations context. Auto-generated code requires an explicit '#nullable' directive in source. 
```